### PR TITLE
Rework the command structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "opentag"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentag"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Sujal Bolia <sujalbolia@gmail.com>"]
 edition = "2024"
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -2,27 +2,82 @@
 
 `opentag` (binary name: `ot`) is a command-line tool that opens a tagged path or URL using the configured system program.
 
-Tags are defined in a `json` data file. See the [Defining Tags](#defining-tags) section for more information about this file.
-
-The tags are added to the application as "subcommands" at run-time and appear in the help text.
-
 `opentag` is useful when you have a bunch of websites and files you regularly open. Instead of adding bookmarks to different browsers and navigating through your file system or typing the file paths and URLs by hand each time, you can simply add them as tags and instantly open them with a short command. Tags can be grouped as subtags, which can have even more subtags! You can also provide helpful descriptions for each tag.
+
+## Usage
+
+Some example commands based on the configuration in the [Defining Tags](#defining-tags) section:
+
+```sh
+# Opens https://example.com
+$ ot example
+# Same as above
+$ ot exa
+# Opens the file at `~/opentag/README.md`
+$ ot exa readme
+# Opens `https://github.com`
+$ ot web github
+# Same as above
+$ ot web gh
+
+# Lists all global level tags
+$ ot -l
+# Lists all subtags under the "example" tag
+$ ot example -l
+
+# Prints "https://example.com"
+$ ot example -p
+# Opens "https://github.com" and copies the URL to the clipboard
+$ ot web gh -c
+# Copies "https://github.com" to the clipboard
+$ ot web gh -C
+# Opens "https://github.com" with Firefox (if installed)
+# instead of the default browser
+$ ot web gh -A firefox
+
+# Adds a new subtag "google" under "example" with a URL,
+# aliases "alphabet" and "search", and a description
+$ ot example add google --path https://google.com --aliases alphabet,search --about "Opens google.com"
+
+# Removes the subtag we added above
+$ ot example google remove
+
+# Updates the "web" tag by adding "net" as an alias
+$ ot web update --alias net
+# Updates the "web" tag by removing all aliases and the about text
+# (passing a flag with no value clears it)
+$ ot web update --alias --about
+```
+
+Run `ot -h` to see a brief overview (shown below), or `ot --help` for the full help text. You can also view help for specific commands (add, remove, update) and for any tags you define.
+
+```txt
+opentag 1.0.0
+Sujal Bolia <sujalbolia@gmail.com>
+
+opentag (ot) opens a tagged path or URL using the configured system program.
+
+Usage: ot [OPTIONS]
+       ot [OPTIONS] <COMMAND>
+
+Commands:
+  add     Add a new tag [aliases: -a]
+  remove  Remove an existing tag [aliases: -r]
+  update  Update an existing tag [aliases: -u]
+
+Options:
+  -p, --print           Print the path or the URL instead of opening it
+  -A, --app <APP-NAME>  Specify the app to open the path or the URL with
+  -c, --copy            Copy the path or the URL to the system's clipboard
+  -C, --silent-copy     Copy the path or the URL to the system's clipboard without opening the path
+  -l, --list            List all global tags or subtags of specified tag
+  -h, --help            Print help (see more with '--help')
+  -V, --version         Print version
+```
 
 ## Defining Tags
 
-Tags are defined in a `json` data file. You do not need to create or edit the file directly, you can use the `--add`, `--remove`, and `--update` options.
-
-### Location
-
-By default, the location of this file is `$DATA_DIR/opentag/tags.json` where `$DATA_DIR` is as follows:
-
-| Platform |                `$DATA_DIR`                 |
-| :------: | :----------------------------------------: |
-|  Linux   |         `/home/Alice/.local/share`         |
-|  macOS   | `/Users/Alice/Library/Application Support` |
-| Windows  |      `C:\Users\Alice\AppData\Roaming`      |
-
-You can override this by setting the `OPENTAG_DATA` environment variable as the path of the tags file. The environment variable takes precedence over the default location.
+Tags are defined in a `json` data file. You should use the `add`, `remove`, and `update` commands to manage tags instead of editing the file directly.
 
 ### Structure
 
@@ -65,86 +120,17 @@ This will create two "global" tags: `example` and `web`. The `example` tag has t
 
 Note that the `names` key has an alias (`name`) and can either be a string or a list of strings. Similarly, `url` is an alias of `path`.
 
-## Usage
+### Location
 
-Some example commands based on the above configuration:
+By default, the location of this file is `$DATA_DIR/opentag/tags.json` where `$DATA_DIR` is as follows:
 
-```sh
-# VALID:
+| Platform |                `$DATA_DIR`                 |
+| :------: | :----------------------------------------: |
+|  Linux   |         `/home/Alice/.local/share`         |
+|  macOS   | `/Users/Alice/Library/Application Support` |
+| Windows  |      `C:\Users\Alice\AppData\Roaming`      |
 
-# Opens https://example.com
-$ ot example
-# Same as above
-$ ot exa
-# Opens the file at `~/opentag/README.md`
-$ ot exa readme
-# Opens `https://github.com`
-$ ot web github
-# Same as above
-$ ot web gh
-
-# Prints "https://example.com"
-$ ot -p example
-
-# Opens "https://github.com" and copies the URL to the clipboard
-$ ot -c web gh
-
-# Copies "https://github.com" to the clipboard
-$ ot -C web gh
-
-# Opens https://github.com with Firefox (if installed)
-# instead of the default browser
-$ ot -A firefox web gh
-
-# Add a new tag
-$ ot -a
-
-# Remove an existing tag
-$ ot -r
-
-# Update an existing tag
-$ ot -u
-
-# INVALID:
-
-# `exaaample` is not a valid subtag
-$ ot exaaample
-# `web github` is not a subtag under `example`
-$ ot example web github
-# `main` is not a "global" tag, it is defined under `example`
-$ ot main
-# `web` does not have a path or URL -- a subtag must be used
-$ ot web
-```
-
-The help text generated from the above configuration is as follows:
-
-```txt
-opentag 0.0.1
-Sujal Bolia <sujalbolia@gmail.com>
-
-opentag (ot) opens a tagged path or URL using the configured system program.
-
-USAGE:
-    ot <--add|--remove|--update|--list>
-    ot [OPTIONS|--list] <TAG>
-
-OPTIONS:
-    -a, --add            Add a new tag.
-    -A, --app <app>      Specify the app to open the path or the URL with.
-    -c, --copy           Copy the path or the URL to the system's clipboard.
-    -C, --silent-copy    Copy the path or the URL to the system's clipboard without opening the path.
-    -h, --help           Print help information
-    -l, --list           List all global tags or subtags of specified tag.
-    -p, --print          Print the path or the URL instead of opening it.
-    -r, --remove         Remove an existing tag.
-    -u, --update         Update an existing tag.
-    -V, --version        Print version information
-
-TAGS:
-    example    Opens example.com [aliases: exv]
-    web        Defines web tabs. A subtag must be used.
-```
+You can override this by setting the `OPENTAG_DATA` environment variable as the path of the tags file. The environment variable takes precedence over the default location.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ Sujal Bolia <sujalbolia@gmail.com>
 
 opentag (ot) opens a tagged path or URL using the configured system program.
 
-Usage: ot [OPTIONS]
-       ot [OPTIONS] <COMMAND>
+Usage: ot [OPTIONS] [COMMAND-OR-TAG]
 
 Commands:
   add     Add a new tag [aliases: -a]

--- a/src/app.rs
+++ b/src/app.rs
@@ -59,30 +59,30 @@ pub(crate) fn get_global_args() -> [Arg; 5] {
             .short('p')
             .long("print")
             .action(ArgAction::SetTrue)
-            .help("Prints the path or the URL instead of opening it."),
+            .help("Print the path or the URL instead of opening it"),
         Arg::new("app")
             .short('A')
             .long("app")
             .num_args(1)
             .value_name("APP-NAME")
             .conflicts_with_all(["print", "silent-copy"])
-            .help("Specifies the app to open the path or the URL with."),
+            .help("Specify the app to open the path or the URL with"),
         Arg::new("copy")
             .short('c')
             .long("copy")
             .action(ArgAction::SetTrue)
-            .help("Copies the path or the URL to the system's clipboard."),
+            .help("Copy the path or the URL to the system's clipboard"),
         Arg::new("silent-copy")
             .short('C')
             .long("silent-copy")
             .action(ArgAction::SetTrue)
-            .help("Copies the path or the URL to the system's clipboard without opening the path."),
+            .help("Copy the path or the URL to the system's clipboard without opening the path"),
         Arg::new("list")
             .short('l')
             .long("list")
             .conflicts_with_all(["copy", "print", "app", "silent-copy"])
             .action(ArgAction::SetTrue)
-            .help("Lists all global tags or subtags of specified tag."),
+            .help("List all global tags or subtags of specified tag"),
     ]
 }
 
@@ -95,7 +95,7 @@ pub(crate) fn get_default_subcommands() -> [Command; 3] {
             .long("path")
             .num_args(0..=1)
             .value_name("PATH")
-            .help("Sets the path/URL of the tag"),
+            .help("Set the path/URL of the tag"),
         Arg::new("alias")
             .short('A')
             .long("alias")
@@ -103,17 +103,18 @@ pub(crate) fn get_default_subcommands() -> [Command; 3] {
             .value_name("ALIAS(ES)")
             .value_parser(tag_aliases_parser)
             .num_args(0..=1)
-            .help("Sets alias(es) for the tag. Multiple aliases must be comma-separated."),
+            .help("Set alias(es) for the tag")
+            .long_help("Set alias(es) for the tag. Multiple aliases must be comma-separated."),
         Arg::new("about")
             .long("about")
             .num_args(0..=1)
             .value_name("TEXT")
-            .help("Sets the about text for the tag"),
+            .help("Set the about text for the tag"),
         Arg::new("app")
             .long("app")
             .num_args(0..=1)
             .value_name("APP-NAME")
-            .help("Specifies the app to open the path or the URL with"),
+            .help("Specify the app to open the path or the URL with"),
     ];
 
     [
@@ -123,22 +124,22 @@ pub(crate) fn get_default_subcommands() -> [Command; 3] {
                 Arg::new("name")
                     .value_parser(tag_name_parser)
                     .value_name("TAG-NAME")
-                    .help("Sets the name of the tag"),
+                    .help("Set the name of the tag"),
             )
             .args(common_args.clone())
-            .about("Adds a new tag")
-            .long_about("Adds a new tag. If no name is provided, the command enters interactive mode."),
+            .about("Add a new tag")
+            .long_about("Add a new tag. If no name is provided, the command enters interactive mode."),
         Command::new("remove")
             .visible_short_flag_alias('r')
-            .about("Removes an existing tag")
             .arg(
                 Arg::new("no-prompt")
                     .short('N')
                     .long("no-prompt")
                     .action(ArgAction::SetTrue)
-                    .help("Disables the confirmation prompt when removing a tag"),
+                    .help("Disable the confirmation prompt when removing a tag"),
             )
-            .long_about("Removes an existing tag. If no tag is specified, the command enters interactive mode."),
+            .about("Remove an existing tag")
+            .long_about("Remove an existing tag. If no tag is specified, the command enters interactive mode."),
         Command::new("update")
             .visible_short_flag_alias('u')
             .arg(
@@ -147,10 +148,10 @@ pub(crate) fn get_default_subcommands() -> [Command; 3] {
                     .long("name")
                     .value_name("TAG-NAME")
                     .value_parser(tag_name_parser)
-                    .help("Sets the name of the tag"),
+                    .help("Set the name of the tag"),
             )
             .args(common_args)
-            .about("Updates an existing tag")
-            .long_about("Updates an existing tag. If no tag is specified, the command enters interactive mode."),
+            .about("Update an existing tag")
+            .long_about("Update an existing tag. If no tag is specified, the command enters interactive mode."),
     ]
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,9 +21,7 @@ const HELP_TEMPLATE: &str = color_print::cstr!(
     r#"{before-help}<g><s>{bin}</></> {version}
 {author-with-newline}
 {about-with-newline}
-{usage-heading}
-  ot <<--add|--remove|--update|--list>>
-  ot [OPTIONS|--list] <<TAG>>
+{usage-heading} {usage}
 
 {all-args}{after-help}"#
 );
@@ -37,7 +35,6 @@ pub(crate) fn create_tags_app(tags: &Tags) -> Command {
         .long_about(ABOUT)
         .help_template(HELP_TEMPLATE)
         .hide_possible_values(true)
-        .subcommand_help_heading("Tags")
         .styles(
             Styles::styled()
                 .header(AnsiColor::Yellow.on_default().bold().underline())

--- a/src/app.rs
+++ b/src/app.rs
@@ -43,7 +43,7 @@ pub(crate) fn create_tags_app(tags: &Tags) -> Command {
                 .placeholder(AnsiColor::Green.on_default())
                 .valid(AnsiColor::Cyan.on_default()),
         )
-        .args(get_args())
+        .args(get_global_args())
         .group(
             ArgGroup::new("cmd-req")
                 .args(["print", "copy", "silent-copy", "app"])
@@ -53,7 +53,7 @@ pub(crate) fn create_tags_app(tags: &Tags) -> Command {
         .subcommands(tags.iter().map(command_from_tag))
 }
 
-pub(crate) fn get_args() -> [Arg; 5] {
+pub(crate) fn get_global_args() -> [Arg; 5] {
     [
         Arg::new("print")
             .short('p')

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,7 @@ const HELP_TEMPLATE: &str = color_print::cstr!(
 {all-args}{after-help}"#
 );
 
-pub fn create_tags_app(tags: &Tags) -> Command {
+pub(crate) fn create_tags_app(tags: &Tags) -> Command {
     clap::command!()
         .arg_required_else_help(true)
         .subcommand_negates_reqs(true)

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,19 +21,18 @@ const HELP_TEMPLATE: &str = color_print::cstr!(
     r#"{before-help}<g><s>{bin}</></> {version}
 {author-with-newline}
 {about-with-newline}
-{usage-heading} {usage}
+{usage-heading} <g>{bin-name} [OPTIONS] [COMMAND-OR-TAG]</>
 
 {all-args}{after-help}"#
 );
 
 pub(crate) fn create_tags_app(tags: &Tags) -> Command {
-    clap::command!()
+    let app = clap::command!()
         .arg_required_else_help(true)
         .subcommand_negates_reqs(true)
         .disable_help_subcommand(true)
         .about(ABOUT.trim_start().lines().next())
         .long_about(ABOUT)
-        .help_template(HELP_TEMPLATE)
         .hide_possible_values(true)
         .styles(
             Styles::styled()
@@ -50,7 +49,9 @@ pub(crate) fn create_tags_app(tags: &Tags) -> Command {
                 .multiple(true),
         )
         .subcommands(get_default_subcommands())
-        .subcommands(tags.iter().map(command_from_tag))
+        .subcommands(tags.iter().map(command_from_tag));
+
+    app.help_template(get_help_template())
 }
 
 pub(crate) fn get_global_args() -> [Arg; 5] {
@@ -154,4 +155,8 @@ pub(crate) fn get_default_subcommands() -> [Command; 3] {
             .about("Update an existing tag")
             .long_about("Update an existing tag. If no tag is specified, the command enters interactive mode."),
     ]
+}
+
+fn get_help_template() -> String {
+    HELP_TEMPLATE.replace("{bin-name}", option_env!("CARGO_BIN_NAME").unwrap_or("ot"))
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,7 +10,7 @@ use crate::Tag;
 use crate::error::Result;
 use crate::tag::{self, Tags};
 
-pub const DEFAULT_SUBCOMMAND_NAMES: [&str; 3] = ["add", "remove", "update"];
+pub(crate) const DEFAULT_SUBCOMMAND_NAMES: [&str; 3] = ["add", "remove", "update"];
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct MatchFlags {
@@ -42,7 +42,7 @@ impl MatchFlags {
 /// Runs the command for the given tag.
 ///
 /// Returns `true` if the tag is updated.
-pub fn run_tag(tag: &mut Tag, flags: MatchFlags) -> Result<()> {
+pub(crate) fn run_tag(tag: &mut Tag, flags: MatchFlags) -> Result<()> {
     if flags.list {
         // TODO: This is a terrible hack. Write own implementation.
         if !tag.subtags.is_empty() {
@@ -118,7 +118,7 @@ fn select_tag<'a>(
 }
 
 /// Runs the add command.
-pub fn add(tags: &mut Tags) -> Result<()> {
+pub(crate) fn interactive_add(tags: &mut Tags) -> Result<()> {
     let names: Vec<_> = Input::<String>::new()
         .with_prompt("Enter tag name and aliases (comma-separated; at least one)")
         .interact_text()?
@@ -166,7 +166,7 @@ pub fn add(tags: &mut Tags) -> Result<()> {
 }
 
 /// Runs the remove command.
-pub fn remove(tags: &mut Tags, prompt: bool) -> Result<bool> {
+pub(crate) fn interactive_remove(tags: &mut Tags, prompt: bool) -> Result<bool> {
     let Some(tag) = select_tag(
         tags,
         "Select the parent tag (press `esc` to quit)",
@@ -189,7 +189,7 @@ pub fn remove(tags: &mut Tags, prompt: bool) -> Result<bool> {
 }
 
 /// Runs the update command.
-pub fn update(tags: &mut Tags) -> Result<bool> {
+pub(crate) fn interactive_update(tags: &mut Tags) -> Result<bool> {
     let Some(tag) = select_tag(
         tags,
         "Select the parent tag (press `esc` to quit)",
@@ -256,16 +256,16 @@ pub(crate) fn run_global_default_command(
             add_tag_inline(tag, &mut tags)?;
             tag::write_tags(tags, path)?;
         } else {
-            add(&mut tags)?;
+            interactive_add(&mut tags)?;
             tag::validate_and_write_tags(tags, path)?;
         }
         println!("\nAdded tag.");
     } else if name == "remove" {
-        if remove(&mut tags, !matches.get_flag("no-prompt"))? {
+        if interactive_remove(&mut tags, !matches.get_flag("no-prompt"))? {
             tag::write_tags(tags, path)?;
             println!("\nRemoved tag.");
         }
-    } else if name == "update" && update(&mut tags)? {
+    } else if name == "update" && interactive_update(&mut tags)? {
         tag::validate_and_write_tags(tags, path)?;
         println!("\nUpdated tag.");
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -62,7 +62,7 @@ pub(crate) fn run_tag(tag: &mut Tag, options: MatchOptions) -> Result<()> {
 
     if options.info {
         print_tag_info(tag)?;
-        if options.copy && tag.path.is_none() {
+        if !options.copy || tag.path.is_none() {
             return Ok(());
         }
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,7 +13,7 @@ use crate::tag::{self, Tags};
 pub(crate) const DEFAULT_SUBCOMMAND_NAMES: [&str; 3] = ["add", "remove", "update"];
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct MatchFlags {
+pub(crate) struct MatchOptions {
     pub(crate) print: bool,
     pub(crate) copy: bool,
     pub(crate) list: bool,
@@ -21,9 +21,9 @@ pub(crate) struct MatchFlags {
     pub(crate) app: Option<String>,
 }
 
-impl MatchFlags {
+impl MatchOptions {
     pub(crate) fn from_matches<const N: usize>(lom: [ArgMatches; N]) -> Self {
-        let mut flags = MatchFlags::default();
+        let mut flags = MatchOptions::default();
 
         for mut matches in lom {
             flags.list |= matches.get_flag("list");
@@ -42,8 +42,8 @@ impl MatchFlags {
 /// Runs the command for the given tag.
 ///
 /// Returns `true` if the tag is updated.
-pub(crate) fn run_tag(tag: &mut Tag, flags: MatchFlags) -> Result<()> {
-    if flags.list {
+pub(crate) fn run_tag(tag: &mut Tag, options: MatchOptions) -> Result<()> {
+    if options.list {
         // TODO: This is a terrible hack. Write own implementation.
         if !tag.subtags.is_empty() {
             let app = Command::new("list-subcommands")
@@ -67,15 +67,15 @@ pub(crate) fn run_tag(tag: &mut Tag, flags: MatchFlags) -> Result<()> {
         return Err(Error::TagWithNoPath.into());
     };
 
-    if flags.copy || flags.silent_copy {
+    if options.copy || options.silent_copy {
         let mut clipboard = Clipboard::new()?;
         clipboard.set_text(path.to_string())?;
     }
 
-    if flags.print {
+    if options.print {
         println!("{}", path);
-    } else if !flags.silent_copy {
-        if let Some(app) = flags.app.as_ref().or(tag.app.as_ref()) {
+    } else if !options.silent_copy {
+        if let Some(app) = options.app.as_ref().or(tag.app.as_ref()) {
             open::with(path, app)
         } else {
             open::that(path)

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,38 @@ use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 /// Result type used throughout the crate.
 pub(crate) type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+/// Error type used throughout the crate.
+#[derive(Debug, Clone)]
+pub(crate) enum Error {
+    NameInUse(String),
+    ReservedName(String),
+    MissingName,
+    NoTagFound,
+    EmptyName,
+    NameWithSpaces,
+    NameBeginsWithHyphen,
+    TagWithNoPath,
+    UnexpectedCommand(String),
+}
+
+impl std::error::Error for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::NameInUse(n) => write!(f, "a tag with name `{n}` already exists"),
+            Error::ReservedName(n) => write!(f, "`{n}` cannot be used as a tag name"),
+            Error::MissingName => write!(f, "there must be at least one name"),
+            Error::NoTagFound => write!(f, "no tag found"),
+            Error::EmptyName => write!(f, "tag names cannot be empty"),
+            Error::NameWithSpaces => write!(f, "tag names cannot contain spaces"),
+            Error::NameBeginsWithHyphen => write!(f, "tag names cannot begin with hyphens"),
+            Error::TagWithNoPath => write!(f, "tag has no path or URL"),
+            Error::UnexpectedCommand(c) => write!(f, "unexpected command: {c}"),
+        }
+    }
+}
+
 /// Prints the error on the `stderr` and exits with the provided exit code.
 ///
 /// "error: " is displayed before the error message. The "error" is displayed in

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,13 +4,13 @@ use std::io::Write;
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 /// Result type used throughout the crate.
-pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub(crate) type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 /// Prints the error on the `stderr` and exits with the provided exit code.
 ///
 /// "error: " is displayed before the error message. The "error" is displayed in
 /// red and bold if possible.
-pub fn exit<T: Display>(err: T, code: i32) -> ! {
+pub(crate) fn exit<T: Display>(err: T, code: i32) -> ! {
     print_error(&err).unwrap_or_else(|_| eprintln!("error: {}", err));
     std::process::exit(code);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod error;
 mod parser;
 mod tag;
 
-use commands::MatchFlags;
+use commands::MatchOptions;
 use error::{Error, Result, exit};
 use tag::Tag;
 
@@ -30,7 +30,7 @@ fn run_app() -> Result<()> {
                 tag::validate_and_write_tags(tags, &path)?;
                 println!("{action} tag.");
             } else {
-                commands::run_tag(tag, MatchFlags::from_matches([matches, ssm]))?;
+                commands::run_tag(tag, MatchOptions::from_matches([matches, ssm]))?;
             }
         } else {
             return Err(Error::NoTagFound.into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod parser;
 mod tag;
 
 use commands::MatchFlags;
-use error::{Result, exit};
+use error::{Error, Result, exit};
 use tag::Tag;
 
 fn run_app() -> Result<()> {
@@ -33,7 +33,7 @@ fn run_app() -> Result<()> {
                 commands::run_tag(tag, MatchFlags::from_matches([matches, ssm]))?;
             }
         } else {
-            return Err("no tag found".into());
+            return Err(Error::NoTagFound.into());
         }
     } else if matches.get_flag("list") {
         if app.has_subcommands() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod commands;
 mod error;
+mod parser;
 mod tag;
 
 use error::{Result, exit};
@@ -21,8 +22,13 @@ fn run_app() -> Result<()> {
             return Err("this argument cannot be used with a tag".into());
         }
 
-        if let Some(tag) = tag::find_tag(&tags, name, sub_matches) {
-            commands::run_tag(tag, &matches)?;
+        if let Some((tag, sub_matches)) = tag::find_tag_and_sub_match(&mut tags, name, sub_matches)
+        {
+            let updated = commands::run_tag(tag, sub_matches)?;
+            if updated {
+                tag::validate_and_write_tags(tags, &path)?;
+                println!("Updated tag.")
+            }
         } else {
             return Err("no tag found".into());
         }
@@ -51,7 +57,7 @@ fn run_app() -> Result<()> {
             return Err("invalid invocation".into());
         };
 
-        tag::write_tags(tags, &path)?;
+        tag::validate_and_write_tags(tags, &path)?;
         println!("\n{} tag.", action);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn run_app() -> Result<()> {
         }
     } else if matches.get_flag("list") {
         if app.has_subcommands() {
-            commands::list_tags(app)?;
+            commands::list_tags_from_app(app, "TAGS")?;
         } else {
             println!("No tags!");
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,21 @@
+#[derive(Debug, Clone)]
+pub(crate) enum TagAttribute {
+    Names(Vec<String>),
+    Path(String),
+    About(String),
+    App(String),
+}
+
+pub(crate) fn update_tag_parser(s: &str) -> Result<TagAttribute, String> {
+    let Some((attrib, val)) = s.split_once('=') else {
+        return Err("expected valid tag attribute and value".to_string());
+    };
+
+    Ok(match attrib {
+        "name" | "N" => TagAttribute::Names(val.split(',').map(String::from).collect()),
+        "path" | "P" => TagAttribute::Path(val.to_string()),
+        "about" => TagAttribute::About(val.to_string()),
+        "default-app" | "D" => TagAttribute::App(val.to_string()),
+        _ => return Err("invalid tag attribute".to_string()),
+    })
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,21 +1,33 @@
-#[derive(Debug, Clone)]
-pub(crate) enum TagAttribute {
-    Names(Vec<String>),
-    Path(String),
-    About(String),
-    App(String),
+use crate::commands;
+
+pub(crate) fn tag_name_parser(s: &str) -> Result<String, String> {
+    if s.is_empty() {
+        return Err("tag names cannot be empty".to_string());
+    } else if s.contains(' ') {
+        return Err("tag names cannot contain spaces".to_string());
+    } else if s.starts_with('-') {
+        return Err("tag names cannot begin with hyphens".to_string());
+    } else if commands::DEFAULT_SUBCOMMAND_NAMES.contains(&s) {
+        return Err(format!("`{s}` cannot be used as a tag name"));
+    }
+
+    Ok(s.to_string())
 }
 
-pub(crate) fn tag_attribute_parser(s: &str) -> Result<TagAttribute, &'static str> {
-    let Some((attrib, val)) = s.split_once('=') else {
-        return Err("expected valid tag attribute and value");
-    };
+pub(crate) fn tag_aliases_parser(s: &str) -> Result<Vec<String>, String> {
+    if s.contains(' ') {
+        return Err("tag aliases cannot contain spaces".to_string());
+    } else if s.starts_with('-') {
+        return Err("tag aliases cannot begin with hyphens".to_string());
+    }
 
-    Ok(match attrib {
-        "name" | "N" => TagAttribute::Names(val.split(',').map(String::from).collect()),
-        "path" | "P" => TagAttribute::Path(val.to_string()),
-        "about" => TagAttribute::About(val.to_string()),
-        "default-app" | "D" => TagAttribute::App(val.to_string()),
-        _ => return Err("invalid tag attribute"),
-    })
+    let names = s.split(',').map(String::from).collect::<Vec<_>>();
+
+    for name in &names {
+        if commands::DEFAULT_SUBCOMMAND_NAMES.contains(&name.as_str()) {
+            return Err(format!("`{name}` cannot be used as a tag name"));
+        }
+    }
+
+    Ok(names)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,9 +6,9 @@ pub(crate) enum TagAttribute {
     App(String),
 }
 
-pub(crate) fn update_tag_parser(s: &str) -> Result<TagAttribute, String> {
+pub(crate) fn tag_attribute_parser(s: &str) -> Result<TagAttribute, &'static str> {
     let Some((attrib, val)) = s.split_once('=') else {
-        return Err("expected valid tag attribute and value".to_string());
+        return Err("expected valid tag attribute and value");
     };
 
     Ok(match attrib {
@@ -16,6 +16,6 @@ pub(crate) fn update_tag_parser(s: &str) -> Result<TagAttribute, String> {
         "path" | "P" => TagAttribute::Path(val.to_string()),
         "about" => TagAttribute::About(val.to_string()),
         "default-app" | "D" => TagAttribute::App(val.to_string()),
-        _ => return Err("invalid tag attribute".to_string()),
+        _ => return Err("invalid tag attribute"),
     })
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,31 +1,31 @@
-use crate::commands;
+use crate::{Error, commands};
 
-pub(crate) fn tag_name_parser(s: &str) -> Result<String, String> {
+pub(crate) fn tag_name_parser(s: &str) -> Result<String, Error> {
     if s.is_empty() {
-        return Err("tag names cannot be empty".to_string());
+        return Err(Error::EmptyName);
     } else if s.contains(' ') {
-        return Err("tag names cannot contain spaces".to_string());
+        return Err(Error::NameWithSpaces);
     } else if s.starts_with('-') {
-        return Err("tag names cannot begin with hyphens".to_string());
+        return Err(Error::NameBeginsWithHyphen);
     } else if commands::DEFAULT_SUBCOMMAND_NAMES.contains(&s) {
-        return Err(format!("`{s}` cannot be used as a tag name"));
+        return Err(Error::ReservedName(s.to_string()));
     }
 
     Ok(s.to_string())
 }
 
-pub(crate) fn tag_aliases_parser(s: &str) -> Result<Vec<String>, String> {
+pub(crate) fn tag_aliases_parser(s: &str) -> Result<Vec<String>, Error> {
     if s.contains(' ') {
-        return Err("tag aliases cannot contain spaces".to_string());
+        return Err(Error::NameWithSpaces);
     } else if s.starts_with('-') {
-        return Err("tag aliases cannot begin with hyphens".to_string());
+        return Err(Error::NameBeginsWithHyphen);
     }
 
     let names = s.split(',').map(String::from).collect::<Vec<_>>();
 
     for name in &names {
         if commands::DEFAULT_SUBCOMMAND_NAMES.contains(&name.as_str()) {
-            return Err(format!("`{name}` cannot be used as a tag name"));
+            return Err(Error::ReservedName(name.to_string()));
         }
     }
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use clap::{ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -201,6 +201,14 @@ pub(crate) fn command_from_tag(tag: &Tag) -> Command {
     }
 
     cmd.args(get_global_args())
+        .arg(
+            Arg::new("info")
+                .short('i')
+                .long("info")
+                .action(clap::ArgAction::SetTrue)
+                .conflicts_with_all(["print", "silent-copy", "list"])
+                .help("Shows information about the tag"),
+        )
         .subcommands(get_default_subcommands())
         .subcommands(tag.subtags.iter().map(command_from_tag))
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -110,7 +110,7 @@ pub fn command_from_tag(tag: &Tag) -> Command {
             Arg::new("tag-update")
                 .short('U')
                 .long("update")
-                .value_parser(parser::update_tag_parser)
+                .value_parser(parser::tag_attribute_parser)
                 .action(ArgAction::Append)
                 .help("Edit the specified attribute for the tag."),
         );

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -7,8 +7,8 @@ use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::app::{get_args, get_default_subcommands};
-use crate::commands;
 use crate::error::Result;
+use crate::{Error, commands};
 
 /// Represents a tag.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -153,17 +153,15 @@ fn validate_tags(tags: &Tags) -> Result<()> {
 
         for tag in tags {
             for name in &tag.names {
-                let name_str = name.as_str();
-
-                if seen.contains(name_str) {
-                    return Err(format!("a tag with name `{}` already exists", name_str).into());
+                if seen.contains(name) {
+                    return Err(Error::NameInUse(name.to_string()).into());
                 }
 
-                if commands::DEFAULT_SUBCOMMAND_NAMES.contains(&name_str) {
-                    return Err(format!("`{}` cannot be used as a tag name", name_str).into());
+                if commands::DEFAULT_SUBCOMMAND_NAMES.contains(&name.as_str()) {
+                    return Err(Error::ReservedName(name.to_string()).into());
                 }
 
-                seen.insert(name_str);
+                seen.insert(name);
             }
         }
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -6,7 +6,7 @@ use clap::{ArgMatches, Command};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::app::{get_args, get_default_subcommands};
+use crate::app::{get_default_subcommands, get_global_args};
 use crate::error::Result;
 use crate::{Error, commands};
 
@@ -200,7 +200,7 @@ pub(crate) fn command_from_tag(tag: &Tag) -> Command {
         cmd = cmd.visible_alias(alias);
     }
 
-    cmd.args(get_args())
+    cmd.args(get_global_args())
         .subcommands(get_default_subcommands())
         .subcommands(tag.subtags.iter().map(command_from_tag))
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -207,7 +207,7 @@ pub(crate) fn command_from_tag(tag: &Tag) -> Command {
                 .long("info")
                 .action(clap::ArgAction::SetTrue)
                 .conflicts_with_all(["print", "silent-copy", "list"])
-                .help("Shows information about the tag"),
+                .help("Show information about the tag"),
         )
         .subcommands(get_default_subcommands())
         .subcommands(tag.subtags.iter().map(command_from_tag))


### PR DESCRIPTION
This PR introduces a major redesign of the command structure and improves overall consistency in usage and help messaging.

## Major Changes

- **Converted --add, --remove, and --update flags into subcommands**
These operations are now first-class commands with both interactive and inline functionality.

- **Removed tags from default help output**
Tags are no longer displayed when running --help. Instead, use --list to view available tags.

- **Added --info flag**
Provides additional information about the selected tag.

## Other Updates

- Help texts were reworded for clarity and consistency.
- Internal code was refactored to better support the updated command structure.

## TODO

- [ ] ~~Throw an error when global flags are used with default commands instead of silently ignoring them~~ Not feasible due to the positional flexibility of the global flags
- [x] Update README
